### PR TITLE
Update ECS prod rollout step to draw from preprod

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1078,7 +1078,7 @@ steps:
       AWS_DEFAULT_REGION: eu-west-2
     commands:
       - apk add --update bash python python-dev py-pip build-base jq
-      - TASKDEF=`aws ecs describe-services --cluster vccs-cluster-sit --services vccs-sit-ecs-service | jq --raw-output '.services[0].taskDefinition'`
+      - TASKDEF=`aws ecs describe-services --cluster vccs-cluster-preprod --services vccs-preprod-ecs-service | jq --raw-output '.services[0].taskDefinition'`
       - export build_id=`aws ecs describe-task-definition --task-definition $TASKDEF | jq --raw-output '.taskDefinition.containerDefinitions[0].image' | cut -f 2 -d ':'`
       - apk add curl
       - sh build_utils/check_build_number.sh


### PR DESCRIPTION
Update drone step for ECS prod rollout to pull task definition from pre-prod rather than SIT (as pre-prod sits one down from prod in the pipeline).