### PR TITLE
[CAZB-340] Update page titles

### DIFF
--- a/app/views/air_zones/caz_selection.html.haml
+++ b/app/views/air_zones/caz_selection.html.haml
@@ -1,4 +1,6 @@
+= content_for(:title, "Which Clean Air Zone do you want to drive in?")
 = link_to 'Back', confirm_details_vehicle_checkers_path, class: 'govuk-back-link'
+
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/air_zones/compliance.html.haml
+++ b/app/views/air_zones/compliance.html.haml
@@ -1,3 +1,4 @@
+= content_for(:title, "Clean Air Zone charge")
 = link_to 'Back', caz_selection_air_zones_path, class: 'govuk-back-link', id: 'back-link'
 
 %main.govuk-main-wrapper#main-content{role: 'main'}

--- a/app/views/contact_forms/index.html.haml
+++ b/app/views/contact_forms/index.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, 'Contact Clean Air Zones')
 = link_to 'Back', @return_url, class: 'govuk-back-link'
 
 %main.govuk-main-wrapper#main-content{role: 'main'}

--- a/app/views/contact_forms/result.html.haml
+++ b/app/views/contact_forms/result.html.haml
@@ -1,3 +1,7 @@
+- if alert
+  - content_for(:title, 'Clean Air Zones Contact Form Was Not Sent')
+- else
+  - content_for(:title, 'Clean Air Zones Contact Form Sent')
 = link_to 'Return to the homepage', root_path, class: 'govuk-back-link'
 
 %main.govuk-main-wrapper#main-content{role: 'main'}

--- a/app/views/cookies/index.html.haml
+++ b/app/views/cookies/index.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, 'Cookies')
 = link_to 'Return to the homepage', root_path, class: 'govuk-back-link'
 
 %main.govuk-main-wrapper#main-content{role: 'main'}

--- a/app/views/errors/internal_server_error.html.haml
+++ b/app/views/errors/internal_server_error.html.haml
@@ -1,4 +1,4 @@
-- content_for(:title, 'Sorry, there is a problem with the service - Clean Air Zones - GOV.UK')
+- content_for(:title, 'Sorry, there is a problem with the service')
 
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row

--- a/app/views/errors/not_found.html.haml
+++ b/app/views/errors/not_found.html.haml
@@ -1,4 +1,4 @@
-- content_for(:title, 'Page not found - Clean Air Zones - GOV.UK')
+- content_for(:title, 'Page not found')
 
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row

--- a/app/views/errors/service_unavailable.html.haml
+++ b/app/views/errors/service_unavailable.html.haml
@@ -1,4 +1,4 @@
-- content_for(:title, 'Sorry, the service is unavailable – Clean Air Zones – GOV.UK')
+- content_for(:title, 'Sorry, the service is unavailable')
 
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row

--- a/app/views/vehicle_checkers/cannot_determine.html.haml
+++ b/app/views/vehicle_checkers/cannot_determine.html.haml
@@ -1,4 +1,4 @@
-- content_for(:title, 'Check vehicle compliance')
+- content_for(:title, 'Vehicle details are incomplete')
 = link_to 'Back', confirm_details_vehicle_checkers_path, class: 'govuk-back-link'
 
 %main.govuk-main-wrapper#main-content{role: 'main'}

--- a/app/views/vehicle_checkers/confirm_details.html.haml
+++ b/app/views/vehicle_checkers/confirm_details.html.haml
@@ -1,4 +1,6 @@
+- content_for(:title, 'Are these vehicle details correct?')
 = link_to 'Back', enter_details_vehicle_checkers_path, method: :get, class: 'govuk-back-link'
+
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/vehicle_checkers/enter_details.html.haml
+++ b/app/views/vehicle_checkers/enter_details.html.haml
@@ -1,4 +1,4 @@
-- content_for(:title, 'Check vehicle compliance')
+- content_for(:title, 'Enter the registration details of the vehicle you want to check')
 = link_to 'Back', root_path, class: 'govuk-back-link'
 
 %main.govuk-main-wrapper#main-content{role: 'main'}

--- a/app/views/vehicle_checkers/exemption.html.haml
+++ b/app/views/vehicle_checkers/exemption.html.haml
@@ -1,3 +1,4 @@
+- content_for(:title, 'This vehicle is exempt from charges in all Clean Air Zones')
 = link_to 'Back', enter_details_vehicle_checkers_path, class: 'govuk-back-link'
 
 %main.govuk-main-wrapper#main-content{role: 'main'}

--- a/app/views/vehicle_checkers/incorrect_details.html.haml
+++ b/app/views/vehicle_checkers/incorrect_details.html.haml
@@ -1,5 +1,6 @@
-- content_for(:title, 'Check vehicle compliance')
+- content_for(:title, 'Incorrect vehicle details')
 = link_to 'Back', confirm_details_vehicle_checkers_path, class: 'govuk-back-link'
+
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/vehicle_checkers/non_uk.html.haml
+++ b/app/views/vehicle_checkers/non_uk.html.haml
@@ -1,5 +1,6 @@
-- content_for(:title, 'Check vehicle compliance')
+- content_for(:title, 'Vehicle is registered outside of the UK')
 = link_to 'Back', enter_details_vehicle_checkers_path, class: 'govuk-back-link'
+
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/vehicle_checkers/number_not_found.html.haml
+++ b/app/views/vehicle_checkers/number_not_found.html.haml
@@ -1,5 +1,6 @@
-- content_for(:title, 'Check vehicle compliance')
+- content_for(:title, 'Vehicle details could not be found')
 = link_to 'Back', enter_details_vehicle_checkers_path, class: 'govuk-back-link'
+
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -1,3 +1,5 @@
+= content_for(:title, "Check if you’ll be charged to drive in a Clean Air Zone")
+
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/features/step_definitions/vehicle_checker_steps.rb
+++ b/features/step_definitions/vehicle_checker_steps.rb
@@ -73,7 +73,7 @@ Then('I should see the CAZ Selection page') do
 end
 
 Then('I should see the Service Unavailable page') do
-  expect(page).to have_title 'Sorry, the service is unavailable – Clean Air Zones – GOV.UK'
+  expect(page).to have_title 'Sorry, the service is unavailable'
 end
 
 And("I enter an exempt vehicle's registration") do

--- a/features/vehicle_checker.feature
+++ b/features/vehicle_checker.feature
@@ -10,7 +10,7 @@ Feature: Vehicle Checker
     Then I should see "Start now"
       And I press the Start now button
     Then I should see the Vehicle Checker page
-      And I should see "Check vehicle compliance" title
+      And I should see "Enter the registration details of the vehicle you want to check" title
       And I should see "Enter the registration details of the vehicle you want to check"
 
   Scenario: User enters a correct vehicle's registration and details are correct
@@ -38,7 +38,7 @@ Feature: Vehicle Checker
       And I choose that the details are incorrect
       And I press the Confirm
     Then I should see the Incorrect Details page
-      And I should see "Check vehicle compliance" title
+      And I should see "Incorrect vehicle details" title
       And I should see "Incorrect vehicle details"
       And I press the Search Again link
     Then I am on the enter details page


### PR DESCRIPTION
## Motivation and Context
On outcome of the Accessibility Audit was an observation that the page titles do not match the `<h1>` content of the page. This PR addresses that. 

## Description
JIRA ref:  [CAZB-340](https://eaflood.atlassian.net/browse/CAZB-340)

## How Has This Been Tested?
Manual inspection.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes the link to an issue (if apply)
- [ ] I have added tests to cover my changes.