### PR TITLE
feature/CAZB-341/form-validation-messages

### DIFF
--- a/app/models/confirmation_form.rb
+++ b/app/models/confirmation_form.rb
@@ -53,7 +53,7 @@ class ConfirmationForm
   def filled?
     return true if confirmation.present?
 
-    @message = 'You must choose an answer'
+    @message = 'Select yes if the details are correct'
     false
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,7 +6,7 @@ en:
     country: Where is the vehicle registered?
   vrn_form:
     vrn_missing: Enter the registration number of the vehicle
-    country_missing: You must choose an answer
+    country_missing: Choose UK or Non-UK
     vrn_invalid: Enter the registration number of the vehicle in valid format
     vrn_too_long: The registration number of the vehicle is too long
     vrn_too_short: The registration number of the vehicle is too short
@@ -18,5 +18,3 @@ en:
     404: Not found
   content:
     external_link: Opens in new window - External website
-
-

--- a/features/vehicle_checker.feature
+++ b/features/vehicle_checker.feature
@@ -58,7 +58,7 @@ Feature: Vehicle Checker
     Given I am on the enter details page
       And I enter a vehicle's registration without selecting country
       And I press the Continue
-    Then I should see "You must choose an answer"
+    Then I should see "Choose UK or Non-UK"
 
   Scenario: User fills invalid VRN
     Given I am on the enter details page
@@ -72,7 +72,7 @@ Feature: Vehicle Checker
       And I press the Continue
     Then I should see the Confirm Details page
       And I press the Confirm
-    Then I should see "You must choose an answer"
+    Then I should see "Select yes if the details are correct"
 
   Scenario: Server is unavailable
     Given I am on the enter details page

--- a/spec/models/confirmation_form_spec.rb
+++ b/spec/models/confirmation_form_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe ConfirmationForm, type: :model do
     end
 
     it 'has a proper error message' do
-      expect(form.message).to eq('You must choose an answer')
+      expect(form.message).to eq('Select yes if the details are correct')
     end
   end
 end

--- a/spec/support/shared_examples/invalid_country_input.rb
+++ b/spec/support/shared_examples/invalid_country_input.rb
@@ -3,7 +3,7 @@
 RSpec.shared_examples 'an invalid country input' do
   it 'has a proper error message' do
     expect(form.error_object[:country][:message])
-      .to eq('You must choose an answer')
+      .to eq('Choose UK or Non-UK')
   end
 
   it 'has a proper link value' do


### PR DESCRIPTION
## Motivation and Context
One output from the accessibility audit was the observation that some of the form validation messages could be improved to help users navigate the service.

## Description
JIRA reference: [CAZB-341](https://eaflood.atlassian.net/browse/CAZB-341)

## How Has This Been Tested?
Manual tests and rspec suite.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/38427673/72547479-a303df80-3884-11ea-879a-8219045d7a0d.png)

![image](https://user-images.githubusercontent.com/38427673/72547505-b151fb80-3884-11ea-9277-7d0f81c4b118.png)


## Checklist:
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes the link to an issue (if apply)
- [x] I have added tests to cover my changes.
