### PR TITLE
[CAZB-28, CAZB-31] Update cookies banner to allow use keyboard focus

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,8 +60,8 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.263.0)
-    aws-sdk-core (3.89.0)
+    aws-partitions (1.264.0)
+    aws-sdk-core (3.89.1)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
@@ -125,7 +125,7 @@ GEM
       railties (>= 3.2, < 6.1)
     erubi (1.9.0)
     erubis (2.7.0)
-    ffi (1.11.3)
+    ffi (1.12.1)
     gherkin (5.1.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -319,7 +319,7 @@ GEM
     tilt (2.0.10)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
-    unicode-display_width (1.6.0)
+    unicode-display_width (1.6.1)
     web-console (4.0.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -329,7 +329,7 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (>= 3.0, < 4.0)
-    webmock (3.7.6)
+    webmock (3.8.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -387,4 +387,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.1.1
+   2.0.2

--- a/app/views/layouts/_cookies_banner.haml
+++ b/app/views/layouts/_cookies_banner.haml
@@ -3,7 +3,13 @@
     %p
       Clean Air Zones uses cookies to make the site simpler.
     .cookie-banner__buttons
-      .cookie-banner__button.cookie-banner__button-accept
-        %a.button.govuk-button.govuk-link{href: nil, role: 'button', id: 'close-banner'} Accept cookies
       .cookie-banner__button.cookie-banner__button-settings
-        %a.button.govuk-button.govuk-link{href: cookies_path, role: 'button', id: 'cookie-settings'} Cookie settings
+        %button.button.govuk-button.govuk-link#close-banner{role: 'button', autofocus: true}
+          Accept cookies
+      .cookie-banner__button.cookie-banner__button-settings
+        = button_to 'Cookie settings',
+                    cookies_path,
+                    method: :get,
+                    class: 'button govuk-button govuk-link',
+                    id: 'cookie-settings',
+                    role: 'button'


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[CAZB-28](https://eaflood.atlassian.net/browse/CAZB-28)
[CAZB-31](https://eaflood.atlassian.net/browse/CAZB-31)
## Description
<!--- Describe your changes in detail -->
Now `'Accept cookies'` button receive keyboard focus first and can be clickable by keyboard.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![cookies_button](https://user-images.githubusercontent.com/24584219/72551356-0138be80-3895-11ea-9f5b-44217a905123.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes the link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
