### PR TITLE
If no VRN param passed, handle don't 500

### DIFF
--- a/app/controllers/vehicle_checkers_controller.rb
+++ b/app/controllers/vehicle_checkers_controller.rb
@@ -200,7 +200,8 @@ class VehicleCheckersController < ApplicationController
 
   # Returns uppercased VRN from the query params without any space, eg. 'CU1234'
   def parsed_vrn
-    @parsed_vrn ||= params[:vrn].upcase&.delete(' ')
+    vrn = params[:vrn].presence || ''
+    @parsed_vrn ||= vrn.upcase&.delete(' ')
   end
 
   # Returns vehicles's registration country from the query params, values: 'UK', 'Non-UK', nil


### PR DESCRIPTION
## Motivation and Context
POSTing without parameters to `/vehicle_checkers/enter_details` causes a 500 error. This is triggering alarms.

https://eaflood.atlassian.net/browse/CAZSM-1

## Description
If VRN is not provided default to an empty string. Then the vrn is not nil and validation is correctly handled without encountering an error/exception.

## How Has This Been Tested?
Other than manual testing, I have not tested this change. I am working under the assumption that the drone tests will cover this minor change.

## Checklist:
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.