### PR TITLE
Santitise input to avoid 5XX errors

### DIFF
--- a/app/controllers/air_zones_controller.rb
+++ b/app/controllers/air_zones_controller.rb
@@ -5,7 +5,7 @@
 #
 class AirZonesController < ApplicationController
   # rescues also from 404 -> the rest is in ApplicationController
-  rescue_from BaseApi::Error404Exception, with: :redirect_to_server_unavailable
+  rescue_from BaseApi::Error404Exception, with: :vehicle_not_found
   # 422 HTTP status from API means vehicle data incomplete so the compliance calculation is not possible.
   rescue_from BaseApi::Error422Exception, with: :unable_to_determine_compliance
 
@@ -83,8 +83,12 @@ class AirZonesController < ApplicationController
   # redirects to the {service unavailable page}[rdoc-ref:ErrorsController.service_unavailable]
   #
   def compliance
-    @compliance_outcomes = Compliance.new(vrn, caz, session[:taxi_or_phv]).compliance_outcomes
-    @vrn = vrn
+    if caz.empty?
+      redirect_to confirm_details_vehicle_checkers_path
+    else
+      @compliance_outcomes = Compliance.new(vrn, caz, session[:taxi_or_phv]).compliance_outcomes
+      @vrn = vrn
+    end
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,6 +67,11 @@ class ApplicationController < ActionController::Base
     render template: 'errors/service_unavailable', status: :service_unavailable
   end
 
+  # Redirects to {number not found}[rdoc-ref:VehicleCheckersController.number_not_found]
+  def vehicle_not_found
+    redirect_to number_not_found_vehicle_checkers_path
+  end
+
   # Checks if VRN is present in session.
   # If not, redirects to VehicleCheckersController#enter_details
   def check_vrn

--- a/app/controllers/vehicle_checkers_controller.rb
+++ b/app/controllers/vehicle_checkers_controller.rb
@@ -200,7 +200,8 @@ class VehicleCheckersController < ApplicationController
 
   # Returns uppercased VRN from the query params without any space, eg. 'CU1234'
   def parsed_vrn
-    @parsed_vrn ||= params[:vrn].upcase&.delete(' ')
+    vrn = params[:vrn].presence || ''
+    @parsed_vrn ||= vrn.upcase&.delete(' ')
   end
 
   # Returns vehicles's registration country from the query params, values: 'UK', 'Non-UK', nil

--- a/app/controllers/vehicle_checkers_controller.rb
+++ b/app/controllers/vehicle_checkers_controller.rb
@@ -215,11 +215,6 @@ class VehicleCheckersController < ApplicationController
     country == 'Non-UK'
   end
 
-  # Redirects to {number not found}[rdoc-ref:VehicleCheckersController.number_not_found]
-  def vehicle_not_found
-    redirect_to number_not_found_vehicle_checkers_path
-  end
-
   ##
   # ==== Params
   # * +undetermined+ - status for the vehicle type if it is not possible to determine, eg. 'true'

--- a/spec/requests/air_zones/compliance_spec.rb
+++ b/spec/requests/air_zones/compliance_spec.rb
@@ -39,4 +39,30 @@ RSpec.describe 'AirZonesController - GET #compliance', type: :request do
       expect(response).to redirect_to(cannot_determine_vehicle_checkers_path)
     end
   end
+
+  context 'when api returns 404 status' do
+    before do
+      allow(ComplianceCheckerApi).to receive(:vehicle_compliance)
+        .and_raise(BaseApi::Error404Exception.new(404, '',
+                                                  'message' => 'Not Found'))
+      http_request
+    end
+
+    it 'redirects to vehicle details not found path' do
+      expect(response).to redirect_to(number_not_found_vehicle_checkers_path)
+    end
+  end
+
+  context 'when CAZ is not provided' do
+    let(:caz) { [] }
+
+    before do
+      allow(ComplianceCheckerApi).to receive(:vehicle_compliance)
+      http_request
+    end
+
+    it 'redirects to confirm vehicle details path' do
+      expect(response).to redirect_to(confirm_details_vehicle_checkers_path)
+    end
+  end
 end

--- a/spec/requests/vehicle_checker_controller/validate_vrn_spec.rb
+++ b/spec/requests/vehicle_checker_controller/validate_vrn_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe 'VehicleCheckersController - GET #submit_details', type: :request
     end
   end
 
+  context 'when VRN is not provided' do
+    let(:vrn) { nil }
+
+    it 'redirects to enter details page' do
+      expect(response).to render_template(:enter_details)
+    end
+  end
+
   context 'when registration country is not valid' do
     let(:country) { '' }
 


### PR DESCRIPTION
## Motivation and Context
Correctly sanitise input to avoid 5XX errors. Additionally, correctly handle skipping steps in user journey (perhaps a surprising use of the forward/back button)

The minor 5XX errors are causing alarms to be triggered - increasing noise - making it hard to spot when more serious issues occur.

## Description
- Handle skipping steps in user journey
- Handle no VRN parameter
- Redirect from compliance if no CAZ selected
- If compliance API call 404s redirect redirect to vehicle not found rather than service unavailable
- Unit tests to cover changes

## How Has This Been Tested?
- Current tests still pass and have not been changed
- Added unit tests to cover changes

## Checklist:
- [X] It contains only changes required by issue (does not contain other PR)
- [X] Includes link to an issue (if apply)
- [X] I have added tests to cover my changes.

[CAZSM-1](https://eaflood.atlassian.net/browse/CAZSM-1)