### PR TITLE
Revert "If no VRN param passed, handle don't 500"

### DIFF
--- a/app/controllers/vehicle_checkers_controller.rb
+++ b/app/controllers/vehicle_checkers_controller.rb
@@ -200,8 +200,7 @@ class VehicleCheckersController < ApplicationController
 
   # Returns uppercased VRN from the query params without any space, eg. 'CU1234'
   def parsed_vrn
-    vrn = params[:vrn].presence || ''
-    @parsed_vrn ||= vrn.upcase&.delete(' ')
+    @parsed_vrn ||= params[:vrn].upcase&.delete(' ')
   end
 
   # Returns vehicles's registration country from the query params, values: 'UK', 'Non-UK', nil


### PR DESCRIPTION
Reverts InformedSolutions/JAQU-CAZ-Vehicle-Compliance-Checker-Web#344

This is to understand, in develop, if these changes have affected the freshping monitoring. We have created an alarm to watch the DEV env and see if this revert handles current errors.