### PR TITLE
[CAZB-36] Fix typo in external_link_to helper method

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,7 +26,7 @@ module ApplicationHelper
   end
 
   # Used for external inline links in the app.
-  # Returns a link with blank target and area-label.
+  # Returns a link with blank target and aria-label.
   #
   # Reference: https://www.w3.org/WAI/GL/wiki/Using_aria-label_for_link_purpose
   def external_link_to(text, url, html_options = {})
@@ -34,7 +34,7 @@ module ApplicationHelper
       target: '_blank',
       class: 'govuk-link',
       rel: 'noopener noreferrer',
-      'area-label': "#{html_options[:'area-label'] || text} - #{I18n.t('content.external_link')}"
+      'aria-label': "#{html_options[:'aria-label'] || text} - #{I18n.t('content.external_link')}"
     )
     link_to "#{text} (opens in a new window)", url, html_options
   end


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Jira card:
https://eaflood.atlassian.net/browse/CAZB-36

## Description
<!--- Describe your changes in detail -->
Updated area-label to be aria-label
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
