### PR TITLE
Fix loading fonts

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,15 +21,8 @@ class ApplicationController < ActionController::Base
                                password: ENV['HTTP_BASIC_PASSWORD'],
                                except: %i[build_id health],
                                if: lambda {
-                                 basic_auth_allowed?
-                               }
-
-  # Checks if basic HTTP authentication is enabled
-  def basic_auth_allowed?
-    Rails.env.production? && ENV['HTTP_BASIC_PASSWORD'].present? &&
-      request.path.exclude?('/packs/media')
-  end
-
+                                     Rails.env.production? && ENV['HTTP_BASIC_PASSWORD'].present?
+                                   }
   ##
   # Health endpoint
   #

--- a/config/initializers/check_request_format.rb
+++ b/config/initializers/check_request_format.rb
@@ -4,7 +4,6 @@
 # if the request should be rejected. Used in routes.rb
 class CheckRequestFormat
   def self.matches?(request)
-    Rails.logger.warn("Invalid request format: #{request.format.symbol}")
-    %i[html json xml woff].include?(request.format.symbol)
+    %i[html json xml].include?(request.format.symbol)
   end
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,21 +6,21 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# if Rails.env.production?
-#   defaults = %i[self https]
-#   defaults.push("https://#{ENV['CLOUDFRONT_ENDPOINT']}") if ENV['CLOUDFRONT_ENDPOINT']
-#
-#   Rails.application.config.content_security_policy do |policy|
-#     policy.default_src(:none)
-#     policy.font_src(*defaults, :data)
-#     policy.img_src(*defaults)
-#     policy.object_src(:none)
-#     policy.script_src(*defaults, :unsafe_inline)
-#     policy.style_src(*defaults, :unsafe_inline)
-#     policy.connect_src(*defaults)
-#     policy.frame_ancestors(:none)
-#   end
-# end
+if Rails.env.production?
+  defaults = %i[self https]
+  defaults.push(ENV['CLOUDFRONT_ENDPOINT']) if ENV['CLOUDFRONT_ENDPOINT']
+
+  Rails.application.config.content_security_policy do |policy|
+    policy.default_src(:none)
+    policy.font_src(*defaults, :data)
+    policy.img_src(*defaults)
+    policy.object_src(:none)
+    policy.script_src(*defaults, :unsafe_inline)
+    policy.style_src(*defaults, :unsafe_inline)
+    policy.connect_src(*defaults)
+    policy.frame_ancestors(:none)
+  end
+end
 
 # If you are using UJS then enable automatic nonce generation
 # Rails.application.config.content_security_policy_nonce_generator =

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -31,5 +31,8 @@ const myFileOptions = {
     context: join(sourcePath)
 };
 
+const fileLoader = environment.loaders.get('file').use.find(el => el.loader === 'file-loader');
+fileLoader.options = myFileOptions;
+
 environment.loaders.prepend('erb', erbLoader);
 module.exports = environment;


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issue appears because VCCS was the first rails application which generates `config/webpack/environment.js` file without 
```
const fileLoader = environment.loaders.get('file').use.find(el => el.loader === 'file-loader');
fileLoader.options = myFileOptions;
```
without it fonts and logo paths generates with hash in path, for example
```
https://dev.cleanairzonevehiclecheck.co.uk/packs/media/fonts/bold-b542beb274-v2.woff2
---------
https://dev.cleanairzonevehiclecheck.co.uk/packs/media/fonts/bold-b542beb274-v2-616e5f21.woff2
```
## Description
<!--- Describe your changes in detail -->
![manifest](https://user-images.githubusercontent.com/24584219/81936048-e03d6b80-95f1-11ea-916d-fc1e25e66567.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
