### PR TITLE
Correct Leeds CAZ tariff in compliance page

### DIFF
--- a/app/views/air_zones/compliance.html.haml
+++ b/app/views/air_zones/compliance.html.haml
@@ -68,7 +68,7 @@
             %br
             A private car (Euro 4) in Leeds
             = surround('(', ')') do
-              = link_to('CAZ C', 'https://www.gov.uk/guidance/driving-in-a-clean-air-zone#types-of-clean-air-zones')
+              = link_to('CAZ B', 'https://www.gov.uk/guidance/driving-in-a-clean-air-zone#types-of-clean-air-zones')
             \= £0.00 (No charge)
           %p
             There are


### PR DESCRIPTION
Correct Leeds CAZ tariff in compliance page. This should read B not C.