### PR TITLE
[CAZB-1659] Consider VRNs with leading 0s as invalid for UK

### DIFF
--- a/app/models/vrn_form.rb
+++ b/app/models/vrn_form.rb
@@ -32,7 +32,7 @@ class VrnForm
     if country == 'Non-UK'
       filled_vrn?
     else
-      filled_vrn? && not_to_long? && not_to_short? && valid_format?
+      filled_vrn? && not_to_long? && not_to_short? && valid_format? && not_include_leading_zero?
     end
     filled_country?
     error_object.empty?
@@ -101,6 +101,18 @@ class VrnForm
     false
   end
 
+  # Checks if +vrn+ does not include 0's in the beginning.
+  #
+  # If it does, add error to +error_object+.
+  #
+  # Returns a boolean.
+  def not_include_leading_zero?
+    return true unless vrn.starts_with?('0')
+
+    vrn_error(I18n.t('vrn_form.vrn_invalid'))
+    false
+  end
+
   # Add error message to +error_object+.
   #
   # ==== Attributes
@@ -147,6 +159,10 @@ class VrnForm
     /^[A-Z]{3}[0-9]{2}[A-Z]$/, # AAA99A
     /^[0-9]{3}[A-Z]{3}$/, # 999AAA
     /^[A-Z]{2}[0-9]{4}$/, # AA9999
-    /^[0-9]{4}[A-Z]{2}$/ # 9999AA
+    /^[0-9]{4}[A-Z]{2}$/, # 9999AA
+
+    # The following regex is technically not valid, but is considered as valid
+    # due to the requirement which forces users not to include leading zeros.
+    /^[A-Z]{2,3}$/ # AA, AAA
   ].freeze
 end

--- a/spec/models/vrn_form_spec.rb
+++ b/spec/models/vrn_form_spec.rb
@@ -93,6 +93,14 @@ RSpec.describe VrnForm, type: :model do
       it_behaves_like 'an invalid vrn input', I18n.t('vrn_form.vrn_invalid')
     end
 
+    context 'when VRN starts with 0' do
+      let(:vrn) { '00SGL6' }
+
+      it { is_expected.not_to be_valid }
+
+      it_behaves_like 'an invalid vrn input', I18n.t('vrn_form.vrn_invalid')
+    end
+
     context 'when country in Non-UK' do
       let(:country) { 'Non-UK' }
 
@@ -127,25 +135,19 @@ RSpec.describe VrnForm, type: :model do
 
         it { is_expected.to be_valid }
       end
+
+      context 'when vrn starts with 0' do
+        let(:vrn) { '00SGL6' }
+
+        it { is_expected.to be_valid }
+      end
     end
   end
 
   describe 'VRN formats' do
     describe 'invalid formats' do
-      context 'when VRN is in format AA' do
-        let(:vrn) { 'AB' }
-
-        it { is_expected.not_to be_valid }
-      end
-
       context 'when VRN is in format 99' do
         let(:vrn) { '45' }
-
-        it { is_expected.not_to be_valid }
-      end
-
-      context 'when VRN is in format AAA' do
-        let(:vrn) { 'ABG' }
 
         it { is_expected.not_to be_valid }
       end


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
JIRA Card: https://eaflood.atlassian.net/browse/CAZB-1659

## Description
<!--- Describe your changes in detail -->
* When provided VRN begins with `0` and is marked as the UK, the validation is going to fail due to the wrong format.
* There are possible 2-characters formats like `9A`. Considering the card requirements it should be possible now to pass a single character VRNs for cases like `0G` but after consultation, it was decided that minimal length of VRN should remain 2.
* Updated specs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Manually.

## Screenshots (if appropriate):
<img width="674" alt="Screenshot 2020-07-01 at 11 14 52" src="https://user-images.githubusercontent.com/4506633/86227108-e0d39680-bb8c-11ea-85b1-2ccc41e8f6b0.png">


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
