### PR TITLE
[CAZB-1971] Added mainInfoUrl to API response

### DIFF
--- a/app/api_wrapper/compliance_checker_api.rb
+++ b/app/api_wrapper/compliance_checker_api.rb
@@ -156,6 +156,7 @@ class ComplianceCheckerApi < BaseApi
     # * +name+ - string, eg. "Birmingham"
     # * +cleanAirZoneId+ - UUID, this represents CAZ ID in the DB
     # * +boundaryUrl+ - URL, this represents a link to eg. a map with CAZ boundaries
+    # * +mainInfoUrl+ - URL, this represents a link to general info about CAZ
     #
     # ==== Serialization
     #

--- a/app/models/non_uk_compliant_vehicle_details.rb
+++ b/app/models/non_uk_compliant_vehicle_details.rb
@@ -33,10 +33,9 @@ class NonUkCompliantVehicleDetails
     0
   end
 
-  # Stub for .main_info_url which returns an URL
   # Returns a string, e.g. 'www.example.com'
   def main_info_url
-    cazes_main_info_urls[zone_name]
+    caz_data['mainInfoUrl']
   end
 
   # Returns a string, eg. 'www.example.com'.
@@ -47,14 +46,4 @@ class NonUkCompliantVehicleDetails
   private
 
   attr_reader :caz_data
-
-  # The following data are only returned from API response when compliance is actually calculated.
-  # As we do not calculate the compliance here, the URLs are hardcoded.
-  def cazes_main_info_urls
-    {
-      'Birmingham' => 'https://www.brumbreathes.co.uk/',
-      'Bath' => 'https://www.bathnes.gov.uk/bath-breathes-2021-overview',
-      'Leeds' => 'https://www.leeds.gov.uk/business/environmental-health-for-business/air-quality'
-    }
-  end
 end

--- a/spec/api_wrappers/compliance_checker_api/clean_air_zones_spec.rb
+++ b/spec/api_wrappers/compliance_checker_api/clean_air_zones_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'ComplianceCheckerApi.clean_air_zones' do
         'cleanAirZoneId',
         'name',
         'boundaryUrl',
+        'mainInfoUrl',
         'activeChargeStartDate'
       )
     end

--- a/spec/fixtures/files/caz_list_response.json
+++ b/spec/fixtures/files/caz_list_response.json
@@ -4,6 +4,7 @@
           "cleanAirZoneId": "5cd7441d-766f-48ff-b8ad-1809586fea37",
           "name": "Birmingham",
           "boundaryUrl": "https://www.birmingham.gov.uk/info/20076/pollution/1763/a_clean_air_zone_for_birmingham/3",
+          "mainInfoUrl": "https://www.brumbreathes.co.uk/",
           "activeChargeStartDate": "2019-05-14"
 
       },
@@ -11,6 +12,7 @@
           "cleanAirZoneId": "39e54ed8-3ed2-441d-be3f-38fc9b70c8d3",
           "name": "Leeds",
           "boundaryUrl": "https://www.arcgis.com/home/webmap/viewer.html?webmap=de0120ae980b473982a3149ab072fdfc&extent=-1.733%2c53.7378%2c-1.333%2c53.8621",
+          "mainInfoUrl": "https://www.leeds.gov.uk/business/environmental-health-for-business/air-quality",
           "activeChargeStartDate": "2019-05-14"
       }
   ]

--- a/spec/models/non_uk_compliant_vehicle_details_spec.rb
+++ b/spec/models/non_uk_compliant_vehicle_details_spec.rb
@@ -8,12 +8,14 @@ RSpec.describe NonUkCompliantVehicleDetails, type: :model do
   let(:caz_data) do
     {
       'name' => name,
-      'boundaryUrl' => boundary_url
+      'boundaryUrl' => boundary_url,
+      'mainInfoUrl' => main_info_url
     }
   end
 
   let(:name) { 'Birmingham' }
   let(:boundary_url) { 'www.example.com' }
+  let(:main_info_url) { 'www.main.info' }
 
   describe '.zone_name' do
     it 'returns proper .zone_name value' do
@@ -36,7 +38,7 @@ RSpec.describe NonUkCompliantVehicleDetails, type: :model do
   describe '.main_info_url' do
     it 'returns proper .main_info_url value' do
       expect(subject.main_info_url)
-        .to eq('https://www.brumbreathes.co.uk/')
+        .to eq(main_info_url)
     end
   end
 


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Link to JIRA Card: https://eaflood.atlassian.net/browse/CAZB-1971

## Description
<!--- Describe your changes in detail -->
* Removed hardcoded URLs to main info pages
* Added `mainInfoUrl` data from API response

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Manually

## Screenshots (if appropriate):
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
