### PR TITLE
[CAZB-3323] Fix Back link layout on printed Compliance page

### DIFF
--- a/.drone2.yml
+++ b/.drone2.yml
@@ -237,7 +237,7 @@ steps:
 
     # Invoke sonar scan
   - name: sonar scan
-    image: aosapps/drone-sonar-plugin
+    image: aosapps/drone-sonar-plugin:1.0
     environment:
       SONAR_HOST:
         from_secret: jaqu_lower_sonar_host

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,4 +29,9 @@ module ApplicationHelper
   def service_name
     Rails.configuration.x.service_name
   end
+
+  # Renders back link
+  def back_link(url, text = 'Back')
+    link_to(text, url, class: 'govuk-back-link back-link')
+  end
 end

--- a/app/javascript/styles/application.scss
+++ b/app/javascript/styles/application.scss
@@ -45,3 +45,7 @@ html {
     margin-bottom: 20px;
   }
 }
+
+.back-link {
+  display: block;
+}

--- a/app/views/air_zones/compliance.html.haml
+++ b/app/views/air_zones/compliance.html.haml
@@ -2,7 +2,7 @@
 
 - title_and_header = 'Clean Air Zone charge'
 = content_for(:title, title_and_header)
-= link_to 'Back', confirm_details_vehicle_checkers_path, class: 'govuk-back-link', id: 'back-link'
+= back_link(confirm_details_vehicle_checkers_path)
 
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row

--- a/app/views/static_pages/accessibility_statement.html.haml
+++ b/app/views/static_pages/accessibility_statement.html.haml
@@ -1,4 +1,4 @@
-= link_to 'Return to the homepage', root_path, class: 'govuk-back-link'
+= back_link(root_path, 'Return to the homepage')
 
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row

--- a/app/views/static_pages/cookies.html.haml
+++ b/app/views/static_pages/cookies.html.haml
@@ -1,7 +1,7 @@
 - title_and_header = 'Cookies'
 - content_for(:title, title_and_header)
 
-= link_to 'Return to the homepage', root_path, class: 'govuk-back-link'
+= back_link(root_path, 'Return to the homepage')
 
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row

--- a/app/views/static_pages/privacy_notice.html.haml
+++ b/app/views/static_pages/privacy_notice.html.haml
@@ -1,7 +1,7 @@
 - title_and_header = "Check if you’ll be charged to drive in a Clean Air Zone"
 - content_for(:title, title_and_header)
 
-= link_to 'Return to the homepage', root_path, class: 'govuk-back-link'
+= back_link(root_path, 'Return to the homepage')
 
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row

--- a/app/views/vehicle_checkers/cannot_determine.html.haml
+++ b/app/views/vehicle_checkers/cannot_determine.html.haml
@@ -1,5 +1,5 @@
 - content_for(:title, 'Vehicle details are incomplete')
-= link_to 'Back', confirm_details_vehicle_checkers_path, class: 'govuk-back-link'
+= back_link(confirm_details_vehicle_checkers_path)
 
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row

--- a/app/views/vehicle_checkers/confirm_details.html.haml
+++ b/app/views/vehicle_checkers/confirm_details.html.haml
@@ -1,5 +1,5 @@
 - content_for(:title, 'Are these vehicle details correct?')
-= link_to 'Back', enter_details_vehicle_checkers_path, method: :get, class: 'govuk-back-link'
+= back_link(enter_details_vehicle_checkers_path)
 
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row

--- a/app/views/vehicle_checkers/enter_details.html.haml
+++ b/app/views/vehicle_checkers/enter_details.html.haml
@@ -1,7 +1,7 @@
 - title_and_header = 'Enter the number plate of the vehicle'
 - content_for(:title, title_and_header)
 
-= link_to 'Back', root_path, class: 'govuk-back-link'
+= back_link(root_path)
 
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row

--- a/app/views/vehicle_checkers/exemption.html.haml
+++ b/app/views/vehicle_checkers/exemption.html.haml
@@ -1,5 +1,5 @@
 - content_for(:title, 'This vehicle is exempt from charges in all Clean Air Zones')
-= link_to 'Back', enter_details_vehicle_checkers_path, class: 'govuk-back-link'
+= back_link(enter_details_vehicle_checkers_path)
 
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row

--- a/app/views/vehicle_checkers/incorrect_details.html.haml
+++ b/app/views/vehicle_checkers/incorrect_details.html.haml
@@ -1,5 +1,5 @@
 - content_for(:title, 'Incorrect vehicle details')
-= link_to 'Back', confirm_details_vehicle_checkers_path, class: 'govuk-back-link'
+= back_link(confirm_details_vehicle_checkers_path)
 
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row

--- a/app/views/vehicle_checkers/non_uk.html.haml
+++ b/app/views/vehicle_checkers/non_uk.html.haml
@@ -1,5 +1,5 @@
 - content_for(:title, 'Vehicle is registered outside of the UK')
-= link_to 'Back', enter_details_vehicle_checkers_path, class: 'govuk-back-link'
+= back_link(enter_details_vehicle_checkers_path)
 
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row

--- a/app/views/vehicle_checkers/number_not_found.html.haml
+++ b/app/views/vehicle_checkers/number_not_found.html.haml
@@ -1,5 +1,5 @@
 - content_for(:title, 'Vehicle details could not be found')
-= link_to 'Back', enter_details_vehicle_checkers_path, class: 'govuk-back-link'
+= back_link(enter_details_vehicle_checkers_path)
 
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-3323

## Description
<!--- Describe your changes in detail -->
Added `back_link` helper with css property `display: block`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5519481/95734659-0d1aab00-0c84-11eb-9780-f077799cb914.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
