### PR TITLE
[CAZB-3390] Remove Leeds references from the VCCS UI

### DIFF
--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -7,7 +7,7 @@
       %h1.govuk-heading-l
         = title_and_header
       %p
-        From early 2021 Birmingham and Leeds will be introducing Clean Air Zones where polluting
+        From early 2021 Birmingham and Bath will be introducing Clean Air Zones where polluting
         vehicles will have to pay a daily charge to drive in the zone.
       %p
         Use this service to check if a specific vehicle will be charged when it drives through a

--- a/spec/fixtures/files/caz_list_response.json
+++ b/spec/fixtures/files/caz_list_response.json
@@ -11,12 +11,12 @@
       },
       {
           "cleanAirZoneId": "39e54ed8-3ed2-441d-be3f-38fc9b70c8d3",
-          "name": "Leeds",
-          "boundaryUrl": "https://www.arcgis.com/home/webmap/viewer.html?webmap=de0120ae980b473982a3149ab072fdfc&extent=-1.733%2c53.7378%2c-1.333%2c53.8621",
-          "exemptionUrl": "https://www.leeds.gov.uk/business/environmental-health-for-business/air-quality/exempt-vehicles-clean-air-charging-zone",
-          "mainInfoUrl": "https://www.leeds.gov.uk/business/environmental-health-for-business/air-quality",
+          "name": "Futurecleanairzone",
+          "boundaryUrl": "https://www.test.com",
+          "exemptionUrl": "https://www.test.com",
+          "mainInfoUrl": "https://www.test.com",
           "activeChargeStartDate": "2019-05-14",
-          "operatorName": "Leeds City Council"
+          "operatorName": "Future CAZ Operator"
       },
       {
           "cleanAirZoneId": "131af03c-f7f4-4aef-81ee-aae4f56dbeb5",

--- a/spec/fixtures/files/vehicle_compliance_response.json
+++ b/spec/fixtures/files/vehicle_compliance_response.json
@@ -22,17 +22,17 @@
         },
         {
             "cleanAirZoneId": "39e54ed8-3ed2-441d-be3f-38fc9b70c8d3",
-            "name": "Leeds",
-            "operatorName": "Leeds City Council",
+            "name": "Futurecleanairzone",
+            "operatorName": "Future CAZ Operator",
             "charge": 0.0,
             "tariffCode": "LCC01-TAXI",
             "informationUrls": {
-                "mainInfo": "https://www.leeds.gov.uk/business/environmental-health-for-business/air-quality",
-                "exemptionOrDiscount": "https://www.leeds.gov.uk/business/environmental-health-for-business/air-quality/exempt-vehicles-clean-air-charging-zone",
-                "becomeCompliant": "http://www.leeds.gov.uk/cleanairzone",
-                "boundary": "https://leedscc.maps.arcgis.com/apps/webappviewer/index.html?id=fd8765f4fa614c64808e32a15ed5ee71",
-                "additionalInfo": "https://www.leeds.gov.uk/business/environmental-health-for-business/air-quality?utm_source=Clean_Air_Leeds_Website&utm_medium=referral&utm_term=What_Are_We_Doing",
-                "publicTransportOptions": "https://cleanairleeds.co.uk/what-can-i-do/residents"
+                "mainInfo": "https://www.test.com",
+                "exemptionOrDiscount": "https://www.test.com",
+                "becomeCompliant": "https://www.test.com",
+                "boundary": "https://www.test.com",
+                "additionalInfo": "https://www.test.com",
+                "publicTransportOptions": "https://www.test.com"
             }
         },
         {

--- a/spec/models/compliance_details_base_spec.rb
+++ b/spec/models/compliance_details_base_spec.rb
@@ -52,7 +52,7 @@ describe ComplianceDetailsBase, type: :model do
     end
 
     context 'when another caz name' do
-      let(:name) { 'Leeds' }
+      let(:name) { 'Futurecleanairzone' }
 
       it 'returns a proper value' do
         expect(subject.charging_starts).to eq('Early 2021')


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[CAZB-3390](https://eaflood.atlassian.net/browse/CAZB-3390)

## Description
<!--- Describe your changes in detail -->
Leeds removed from the un-used starter page and replaced it with future CAZ in tests.

## How Has This Been Tested?
Executed rspec/cucumber tests against service. 

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
