### PR TITLE
[NON-JIRA] Improve build speed in dev

### DIFF
--- a/.drone2.yml
+++ b/.drone2.yml
@@ -147,15 +147,6 @@ volumes:
 
 steps:
 
-  # Clean agent images and containers to prevent disk space overuse
-  - name: clean agent
-    image: docker:19.03.11-git
-    commands:
-    - docker system prune -f
-    volumes:
-      - name: docker_sock
-        path: /var/run/docker.sock
-
   # Build docker image
   - name: build
     image: docker:19.03.11-git
@@ -225,12 +216,16 @@ steps:
       registry: 311075478274.dkr.ecr.eu-west-2.amazonaws.com
       dockerfile: Dockerfile.build
       region: eu-west-2
+      use_cache: true
       tags:
         - latest
         - ${DRONE_BUILD_NUMBER}
       build_args:
         - secret_key_base=${DRONE_COMMIT}
         - aws_region=eu-west-2
+    volumes:
+      - name: docker_sock
+        path: /var/run/docker.sock
     when:
       event:
         - push


### PR DESCRIPTION
Improves build speed and allows for docker image caching when pushing to ECR repository. This serves 2 benefits - one in that builds are 3 minutes faster to deploy; second - this reduces the number of pulls issued to Dockerhub (so reduces chance of hitting rate limits).