### PR TITLE
Update mimemagic to 0.3.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,7 +183,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Author of mimemagic gem has decided to change license from MIT to GPL2
and  remove all older versions in the process. Unfortunately this gem is
a dependency of Rails. 

This change broke our CI builds:
http://drone-1587293244.eu-west-2.elb.amazonaws.com/InformedSolutions/JAQU-CAZ-Vehicle-Compliance-Checker-Web/890

We need to update it to the closes version available.

## Description
Old version of mimemagic has been removed https://github.com/rails/rails/issues/41750
This commit bumps the version up to the closest version available.
The only change introduced in 0.3.6 is license change (from MIT to GPL2)

## Additional considerations
In order to resolve the issue in other repos, one needs to run `bundle update mimemagic`,
(which should update it to 0.3.6) and ensure only mimemagic change has been commited