### PR TITLE
Fix build process by bumping mimemagic to 0.3.9

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -11,7 +11,7 @@ ARG aws_region
 ENV AWS_REGION=$aws_region
 
 RUN apk add --no-cache --update build-base linux-headers tzdata nodejs \
- tzdata openssh libxml2-dev libxslt-dev yarn curl-dev sqlite-dev \
+ tzdata openssh libxml2-dev libxslt-dev yarn curl-dev sqlite-dev shared-mime-info \
  && PACKAGES="ca-certificates procps curl pcre libstdc++ libexecinfo" \
  && BUILD_PACKAGES="pcre-dev libexecinfo-dev" \
  && apk add --update $PACKAGES $BUILD_PACKAGES \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -16,7 +16,7 @@ RUN apk add --no-cache --update build-base \
   curl-dev \
   sqlite-dev \
   git \
-  && PACKAGES="ca-certificates procps curl pcre libstdc++ libexecinfo" \
+  && PACKAGES="ca-certificates procps curl pcre libstdc++ libexecinfo shared-mime-info" \
   && BUILD_PACKAGES="pcre-dev libexecinfo-dev" \
   && apk add --update $PACKAGES $BUILD_PACKAGES \
   && rm -rf /var/cache/apk/*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,7 +183,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.3.6)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)


### PR DESCRIPTION
Recently there was a lot of drama around mimemagic gem - at first
mimemagic updated its licence to GPL2 to comply with its dependency
(freedesktop.org.xml) licence. In the process they yanked all
<0.3.6 licences and broke many builds (including ours) as 0.3.4
was direct dependency of Rails.

We have updated our Gemfile.lock to 0.3.6 to get our builds back
to green. This was yesterday. As of Today it looks like mimemagic
changed the owner. New owner extracted freedesktop.org.xml to be an outside
dependency, restored previous MIT licence, and again yanked all versions
<0.3.9 which again broke our build.

This commit bumps version to the closest available. We sincerely hope
we will not have to bump it again tomorrow.

If your build fails, please look at https://github.com/InformedSolutions/JAQU-CAZ-Vehicle-Compliance-Checker-Web/pull/726