### PR TITLE
[CAZB-4715] Use operator name on privacy notice page

### DIFF
--- a/app/models/caz_link_display_data.rb
+++ b/app/models/caz_link_display_data.rb
@@ -4,7 +4,7 @@
 # This class is used to display data in +app/views/static_pages/privacy_notice.html.haml+.
 class CazLinkDisplayData
   # Attribute readers
-  attr_reader :name, :privacy_policy_url, :display_from, :display_order
+  attr_reader :name, :privacy_policy_url, :display_from, :display_order, :operator_name
 
   ##
   # Creates an instance of a class
@@ -15,12 +15,14 @@ class CazLinkDisplayData
   # * +privacy_policy_url+ - string with URL, eg. 'http://example.com'
   # * +display_from+ - date, eg. '2021-03-15
   # * +display_order+ - integer, eg. 3
+  # * +operator_name+ - string, eg. 'Birmingham City Council'
   #
-  def initialize(name:, privacy_policy_url:, display_from:, display_order:)
+  def initialize(name:, privacy_policy_url:, display_from:, display_order:, operator_name:)
     @name = name
     @privacy_policy_url = privacy_policy_url
     @display_from = display_from
     @display_order = display_order
+    @operator_name = operator_name
   end
 
   ##
@@ -30,7 +32,8 @@ class CazLinkDisplayData
   def self.from_list(caz_list)
     caz_list.map do |caz|
       new(name: caz['name'], privacy_policy_url: caz['privacyPolicyUrl'],
-          display_from: Date.parse(caz['displayFrom']), display_order: caz['displayOrder'])
+          display_from: Date.parse(caz['displayFrom']), display_order: caz['displayOrder'],
+          operator_name: caz['operatorName'])
     end
   end
 end

--- a/app/views/static_pages/privacy_notice.html.haml
+++ b/app/views/static_pages/privacy_notice.html.haml
@@ -155,7 +155,7 @@
 
       - @caz_link_display_data.each do |caz_link|
         %p
-          = link_to("#{caz_link.name} privacy policy", caz_link.privacy_policy_url, id: "#{caz_link.name.downcase}-policy-link")
+          = link_to("#{caz_link.operator_name} privacy policy", caz_link.privacy_policy_url, id: "#{caz_link.name.downcase}-policy-link")
 
       %h2.govuk-heading-l
         Customer Contact Centre


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-4715

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
