### PR TITLE
[CAZB-4876] Add js back button to compliance page

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -1,4 +1,6 @@
 # A list of advisory exclusions for `improved-yarn-audit` library.
 # Advisory exclusions to be ignored can either be provided on their own line, or as a comma separated list.
+# Can be tested by running `yarn run improved-yarn-audit` in console.
 1693
 1745
+1748

--- a/app/views/air_zones/compliance.html.haml
+++ b/app/views/air_zones/compliance.html.haml
@@ -2,7 +2,7 @@
 
 - title_and_header = 'Clean Air Zone charge'
 = content_for(:title, title_and_header)
-= back_link(session[:possible_fraud] ? confirm_uk_details_vehicle_checkers_path : confirm_details_vehicle_checkers_path)
+= render 'common/js_back_link'
 
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row

--- a/features/vehicle_checker.feature
+++ b/features/vehicle_checker.feature
@@ -137,8 +137,6 @@ Feature: Vehicle Checker
       And I choose 'Yes' when confirms vehicle details
       And I press the Confirm
       And I should see the Compliance page
-    Then I press the Back link
-      And I should see the Confirm Details page
 
   Scenario: User enters a correct UK vehicle's registration, choose Non-UK country (fraud detection) and choose that vehicle's details are correct
     Given I am on the enter details page
@@ -155,9 +153,6 @@ Feature: Vehicle Checker
       And I choose 'Yes' when confirms vehicle details
       And I press 'Confirm' button
       And I should see the Compliance page
-    Then I press the Back link
-      And I should see the Confirm UK Details page
-      And I should see 'The DVLA holds a record for this vehicle.'
 
   Scenario: User enters a correct UK vehicle's registration, choose Non-UK country (fraud detection) and choose that vehicle's details are incorrect
     Given I am on the enter details page


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! Check application with WAVE Browser Extensions --->
<!--- https://wave.webaim.org/extension --->
<!--- !!! Make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-4876
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
